### PR TITLE
fix gateway delete function by appending Harvest uri

### DIFF
--- a/src/Api/Gateway.php
+++ b/src/Api/Gateway.php
@@ -80,7 +80,7 @@ class Gateway
 
     public function delete($uri)
     {
-        $response = $this->apiClient->delete($uri);
+        $response = $this->apiClient->delete($this->uri . $uri);
 
         return $this->transformResponse($response);
     }


### PR DESCRIPTION
Fixes the missing Harvest API URI in front of the URL used to send a delete command in the API Gateway class.